### PR TITLE
Latest changes for solving DMA/USART issues

### DIFF
--- a/device.c
+++ b/device.c
@@ -51,11 +51,11 @@ device_init(struct uaio_task *self) {
 
     CORO_WAIT(clock_init, NULL);
 
-    DEBUG("Init USART2");
-    usart2_init();
-
     DEBUG("Init DMA");
     dma_init();
+
+    DEBUG("Init USART2");
+    usart2_init();
 
     CORO_FINALLY;
 }

--- a/dma.c
+++ b/dma.c
@@ -24,17 +24,18 @@
 
 void
 dma_init() {
-    // NVIC_SetPriority(DMA1_Channel2_3_IRQn, 0);
     RCC->AHBENR |= RCC_AHBENR_DMA1EN;
-    NVIC_EnableIRQ(DMA1_Channel2_3_IRQn);
+    
+    NVIC_SetPriority(DMA1_Channel4_5_IRQn, 0);
+    NVIC_EnableIRQ(DMA1_Channel4_5_IRQn);
 
-    DMA1_CSELR->CSELR &= ~DMA_CSELR_C2S;
-    DMA1_CSELR->CSELR = 4 << DMA_CSELR_C2S_Pos;
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C4S;
+    DMA1_CSELR->CSELR = 4 << DMA_CSELR_C4S_Pos;
 }
 
 
 void
-DMA1_Channel2_3_IRQHandler() {
+DMA1_Channel4_5_IRQHandler() {
 	// if ((DMA1->ISR)&(1<<22))  // If the Half Transfer Complete Interrupt is set
 	// {
 	// 	memcpy (&MainBuf[indx], &RxBuf[0], RXSIZE/2);
@@ -46,8 +47,8 @@ DMA1_Channel2_3_IRQHandler() {
     DEBUG("Transfer completed");
 
     /* Full transfer */
-	if (DMA1->ISR & DMA_ISR_TCIF2) {
-		DMA1->IFCR |= DMA_ISR_TCIF2;
+	if (DMA1->ISR & DMA_ISR_TCIF4) {
+		DMA1->IFCR |= DMA_ISR_TCIF4;
 	}
 
 }
@@ -62,7 +63,7 @@ dma_memory_to_peripheral_circular(volatile uint32_t *peripheral,
     10: high
     11: very high
     */
-    DMA1_CH2->CCR &= ~(DMA_CCR_PL_1 | DMA_CCR_PL_1);
+    DMA1_CH4->CCR &= ~(DMA_CCR_PL_1 | DMA_CCR_PL_0);
 
     /* Configure data transfer direction, peripheral & memory incremented
        mode, and peripheral & memory data size */
@@ -72,8 +73,8 @@ dma_memory_to_peripheral_circular(volatile uint32_t *peripheral,
     0: read from peripheral
     1: read from memory
     */
-    DMA1_CH2->CCR &= ~DMA_CCR_MEM2MEM;
-    DMA1_CH2->CCR |= DMA_CCR_DIR;
+    DMA1_CH4->CCR &= ~DMA_CCR_MEM2MEM;
+    DMA1_CH4->CCR |= DMA_CCR_DIR;
 
     /* Set the memory and pripheral write chunk size to one byte */
     /*
@@ -82,32 +83,32 @@ dma_memory_to_peripheral_circular(volatile uint32_t *peripheral,
     10: 32 bits
     11: reserved
     */
-    DMA1_CH2->CCR &= ~(DMA_CCR_MSIZE_0 | DMA_CCR_MSIZE_0);
-    DMA1_CH2->CCR &= ~(DMA_CCR_PSIZE_0 | DMA_CCR_PSIZE_0);
+    DMA1_CH4->CCR &= ~(DMA_CCR_MSIZE_1 | DMA_CCR_MSIZE_0);
+    DMA1_CH4->CCR &= ~(DMA_CCR_PSIZE_1 | DMA_CCR_PSIZE_0);
 
     /* Set memory address incement by one byte */
-    DMA1_CH2->CCR |= DMA_CCR_MINC;
+    DMA1_CH4->CCR |= DMA_CCR_MINC;
 
     /* Disable address incrementation on peripheral address */
-    DMA1_CH2->CCR &= ~DMA_CCR_PINC;
+    DMA1_CH4->CCR &= ~DMA_CCR_PINC;
 
     /* Enable circular mode */
-    DMA1_CH2->CCR |= DMA_CCR_CIRC;
+    DMA1_CH4->CCR |= DMA_CCR_CIRC;
 
     /* Enable interrpt after full transfer */
-    DMA1_CH2->CCR |= DMA_CCR_TCIE | DMA_CCR_TEIE | DMA_CCR_HTIE;
+    DMA1_CH4->CCR |= DMA_CCR_TCIE | DMA_CCR_TEIE | DMA_CCR_HTIE;
 
-    /* Set USART1 TX data register address into DMA Channel 4 */
-    DMA1_CH2->CPAR = (uint32_t)peripheral;
+    /* Set USART2 TX data register address into DMA Channel 4 */
+    DMA1_CH4->CPAR = (uint32_t)peripheral;
 
     /* Set pointer to data to be sent */
-    DMA1_CH2->CMAR = (uint32_t)data;
+    DMA1_CH4->CMAR = (uint32_t)data;
 
     /* Set size of data to be sent */
-    DMA1_CH2->CNDTR = count;
+    DMA1_CH4->CNDTR = count;
 
-    /* Enable DMA channel 2 */
-    DMA1_CH2->CCR |= DMA_CCR_EN;
+    /* Enable DMA channel 4 */
+    DMA1_CH4->CCR |= DMA_CCR_EN;
 
     DEBUG("Sending: %.*s", count, data);
 }

--- a/dma.c
+++ b/dma.c
@@ -25,13 +25,13 @@
 void
 dma_init() {
     RCC->AHBENR |= RCC_AHBENR_DMA1EN;
-    
+
     /* DMA channel 4 selection */
     DMA1_CSELR->CSELR &= ~DMA_CSELR_C4S;
     DMA1_CSELR->CSELR |= (0x4U << DMA_CSELR_C4S_Pos);
-    
-    NVIC_SetPriority(DMA1_Channel4_5_IRQn, 0);
+
     NVIC_EnableIRQ(DMA1_Channel4_5_IRQn);
+    NVIC_SetPriority(DMA1_Channel4_5_IRQn, 0);
 }
 
 
@@ -45,10 +45,12 @@ DMA1_Channel4_5_IRQHandler() {
 	// 	if (indx>49) indx=0;
 	// }
 
-    DEBUG("Transfer completed");
-
+    if (DMA1->ISR & DMA_CCR_HTIE) {
+        DEBUG("Half completed");
+    }
     /* Full transfer */
 	if (DMA1->ISR & DMA_ISR_TCIF4) {
+        DEBUG("Transfer completed");
 		DMA1->IFCR |= DMA_ISR_TCIF4;
 	}
 
@@ -57,6 +59,7 @@ DMA1_Channel4_5_IRQHandler() {
 void
 dma_memory_to_peripheral_circular(volatile uint32_t *peripheral,
         const char *data, uint32_t count) {
+    INFO("Starting to send");
     /* Disable DMA */
     DMA1_CH4->CCR &= ~DMA_CCR_EN;
 
@@ -116,6 +119,8 @@ dma_memory_to_peripheral_circular(volatile uint32_t *peripheral,
 
     /* Enable DMA channel 4 */
     DMA1_CH4->CCR |= DMA_CCR_EN;
+
+    INFO("Before enabling uart");
 
     /* Enable USART2 to request from DMA*/
     USART2->CR1 |= USART_CR1_UE;

--- a/dma.c
+++ b/dma.c
@@ -25,12 +25,12 @@
 void
 dma_init() {
     RCC->AHBENR |= RCC_AHBENR_DMA1EN;
-    
+
     NVIC_SetPriority(DMA1_Channel4_5_IRQn, 0);
     NVIC_EnableIRQ(DMA1_Channel4_5_IRQn);
 
-    DMA1_CSELR->CSELR &= ~DMA_CSELR_C4S;
-    DMA1_CSELR->CSELR = 4 << DMA_CSELR_C4S_Pos;
+    /* DMA channel 4 selection */
+    DMA1_CSELR->CSELR |= DMA_CSELR_C4S;
 }
 
 
@@ -56,6 +56,12 @@ DMA1_Channel4_5_IRQHandler() {
 void
 dma_memory_to_peripheral_circular(volatile uint32_t *peripheral,
         const char *data, uint32_t count) {
+    /* Disable DMA */
+    DMA1_CH4->CCR &= ~DMA_CCR_EN;
+
+    /* clear interrupt flags  */
+    DMA1->IFCR |= (DMA_IFCR_CHTIF4 | DMA_IFCR_CGIF4 | DMA_IFCR_CTCIF4);
+
     /* Configure the channel priority to medium level */
     /*
     00: low

--- a/dma.c
+++ b/dma.c
@@ -25,12 +25,13 @@
 void
 dma_init() {
     RCC->AHBENR |= RCC_AHBENR_DMA1EN;
-
+    
+    /* DMA channel 4 selection */
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C4S;
+    DMA1_CSELR->CSELR |= (0x4U << DMA_CSELR_C4S_Pos);
+    
     NVIC_SetPriority(DMA1_Channel4_5_IRQn, 0);
     NVIC_EnableIRQ(DMA1_Channel4_5_IRQn);
-
-    /* DMA channel 4 selection */
-    DMA1_CSELR->CSELR |= DMA_CSELR_C4S;
 }
 
 
@@ -58,9 +59,6 @@ dma_memory_to_peripheral_circular(volatile uint32_t *peripheral,
         const char *data, uint32_t count) {
     /* Disable DMA */
     DMA1_CH4->CCR &= ~DMA_CCR_EN;
-
-    /* clear interrupt flags  */
-    DMA1->IFCR |= (DMA_IFCR_CHTIF4 | DMA_IFCR_CGIF4 | DMA_IFCR_CTCIF4);
 
     /* Configure the channel priority to medium level */
     /*
@@ -104,6 +102,9 @@ dma_memory_to_peripheral_circular(volatile uint32_t *peripheral,
     /* Enable interrpt after full transfer */
     DMA1_CH4->CCR |= DMA_CCR_TCIE | DMA_CCR_TEIE | DMA_CCR_HTIE;
 
+    /* clear interrupt flags  */
+    DMA1->IFCR |= (DMA_IFCR_CHTIF4 | DMA_IFCR_CGIF4 | DMA_IFCR_CTCIF4);
+
     /* Set USART2 TX data register address into DMA Channel 4 */
     DMA1_CH4->CPAR = (uint32_t)peripheral;
 
@@ -115,6 +116,9 @@ dma_memory_to_peripheral_circular(volatile uint32_t *peripheral,
 
     /* Enable DMA channel 4 */
     DMA1_CH4->CCR |= DMA_CCR_EN;
+
+    /* Enable USART2 to request from DMA*/
+    USART2->CR1 |= USART_CR1_UE;
 
     DEBUG("Sending: %.*s", count, data);
 }

--- a/main.c
+++ b/main.c
@@ -32,11 +32,10 @@
 static ASYNC
 startA(struct uaio_task *self) {
     static struct uaio_sleep sleep = {2000};
-    // static struct usart usart2 = {
-    //     .send = "hello\n",
-    //     .sendlen = 6,
-
-    // };
+    static struct usart usart2 = {
+        .send = "hello\n",
+        .sendlen = 6,
+    };
 
     CORO_START;
     INFO("Initializing...");
@@ -50,8 +49,10 @@ startA(struct uaio_task *self) {
         print_date(false);
         print_time();
 
-        // CORO_WAIT(usart2_sendA, &usart2);
-        device_standby();
+        CORO_WAIT(usart2_sendA, &usart2);
+        
+        /* device_standby commented for now to test uart dma */
+        // device_standby();
     }
 
     CORO_FINALLY;

--- a/main.c
+++ b/main.c
@@ -33,8 +33,8 @@ static ASYNC
 startA(struct uaio_task *self) {
     static struct uaio_sleep sleep = {2000};
     static struct usart usart2 = {
-        .send = "hello\n",
-        .sendlen = 6,
+        .send = "hello\r\n",
+        .sendlen = 7,
     };
 
     CORO_START;
@@ -50,7 +50,7 @@ startA(struct uaio_task *self) {
         print_time();
 
         CORO_WAIT(usart2_sendA, &usart2);
-        
+
         /* device_standby commented for now to test uart dma */
         // device_standby();
     }

--- a/stm32/stm32l071xx.h
+++ b/stm32/stm32l071xx.h
@@ -2628,6 +2628,10 @@ typedef struct
 #define GPIOA_AFRL_AFSEL2_AF2_USART2_TX  (GPIO_AF2 << GPIO_AFRL_AFSEL2_Pos)
 #define GPIOA_AFRL_AFSEL3_AF2_USART2_RX  (GPIO_AF2 << GPIO_AFRL_AFSEL3_Pos)
 
+#define GPIO_AF4                         (0x4UL)
+#define GPIOA_AFRL_AFSEL2_AF4_USART2_TX  (GPIO_AF4 << GPIO_AFRL_AFSEL2_Pos)
+#define GPIOA_AFRL_AFSEL3_AF4_USART2_RX  (GPIO_AF4 << GPIO_AFRL_AFSEL3_Pos)
+
 /****************** Bit definition for GPIO_AFRH register ********************/
 #define GPIO_AFRH_AFSEL8_Pos             (0U)
 #define GPIO_AFRH_AFSEL8_Msk             (0xFUL << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x0000000F */

--- a/stm32/stm32l071xx.h
+++ b/stm32/stm32l071xx.h
@@ -6494,7 +6494,7 @@ typedef struct
 #define AES_RNG_LPUART1_IRQHandler     LPUART1_IRQHandler
 #define TIM6_DAC_IRQHandler            TIM6_IRQHandler
 #define RCC_CRS_IRQHandler             RCC_IRQHandler
-#define DMA1_Channel4_5_IRQHandler     DMA1_Channel4_5_6_7_IRQHandler
+#define DMA1_Channel4_5_IRQHandler     DMA1_Channel4_7_IRQHandler
 #define ADC1_IRQHandler                ADC1_COMP_IRQHandler
 
 /**

--- a/stm32/stm32l071xx.h
+++ b/stm32/stm32l071xx.h
@@ -6485,7 +6485,7 @@ typedef struct
 #define AES_RNG_LPUART1_IRQn           LPUART1_IRQn
 #define TIM6_DAC_IRQn                  TIM6_IRQn
 #define RCC_CRS_IRQn                   RCC_IRQn
-#define DMA1_Channel4_5_IRQn           DMA1_Channel4_5_6_7_IRQn
+// #define DMA1_Channel4_5_IRQn           DMA1_Channel4_5_6_7_IRQn
 #define ADC1_IRQn                      ADC1_COMP_IRQn
 
 /* Aliases for __IRQHandler */
@@ -6494,7 +6494,7 @@ typedef struct
 #define AES_RNG_LPUART1_IRQHandler     LPUART1_IRQHandler
 #define TIM6_DAC_IRQHandler            TIM6_IRQHandler
 #define RCC_CRS_IRQHandler             RCC_IRQHandler
-#define DMA1_Channel4_5_IRQHandler     DMA1_Channel4_7_IRQHandler
+// #define DMA1_Channel4_5_IRQHandler     DMA1_Channel4_7_IRQHandler
 #define ADC1_IRQHandler                ADC1_COMP_IRQHandler
 
 /**

--- a/uart.c
+++ b/uart.c
@@ -92,9 +92,7 @@ usart2_init() {
 
     /* BRR register configuration */
     uint32_t baud_rate = 115200;
-    uint16_t uartdiv = system_clock / baud_rate;
-    USART2->BRR = (((uartdiv / 16) << USART_BRR_DIV_MANTISSA_Pos) |
-            ((uartdiv % 16) << USART_BRR_DIV_FRACTION_Pos));
+    USART2->BRR = (uint32_t) system_clock / baud_rate;
 
     /* Enable USART2 Transmitter */
     USART2->CR1 |= USART_CR1_TE;

--- a/uart.c
+++ b/uart.c
@@ -74,8 +74,8 @@ usart2_init() {
     /* Select alternate functions of PA2 and PA3 */
     GPIOA->AFRL &= ~(GPIO_AFRL_AFSEL2_Msk | GPIO_AFRL_AFSEL3_Msk);
     GPIOA->AFRL |=
-        GPIOA_AFRL_AFSEL2_AF2_USART2_TX |
-        GPIOA_AFRL_AFSEL3_AF2_USART2_RX;
+        GPIOA_AFRL_AFSEL2_AF4_USART2_TX |
+        GPIOA_AFRL_AFSEL3_AF4_USART2_RX;
 
     /* Word length: 00: 1 Start bit, 8 data bits, n stop bits */
     USART2->CR1 &= ~(USART_CR1_M1 | USART_CR1_M0);
@@ -96,7 +96,7 @@ ASYNC
 usart2_sendA(struct uaio_task *self, struct usart *state) {
     CORO_START;
 
-    dma_memory_to_peripheral_circular(&USART1->TDR, state->send,
+    dma_memory_to_peripheral_circular(&USART2->TDR, state->send,
             state->sendlen);
 
     CORO_FINALLY;

--- a/uart.c
+++ b/uart.c
@@ -38,7 +38,7 @@ usart2_init() {
     */
     // const char * msg = "Hello\r\n";
 
-    /* Enable clock for GPIOA and USART1 */
+    /* Enable clock for GPIOA and USART2 */
     RCC->IOPENR |= RCC_IOPENR_IOPAEN;
     RCC->APB1ENR |= RCC_APB1ENR_USART2EN;
 
@@ -54,33 +54,30 @@ usart2_init() {
 
     /* TODO: USART2 clock enable during Sleep mode bit */
     /* RCC_APB1SMENR: Bit 17 USART2SMEN */
+    GPIOA->MODER &= ~GPIO_MODER_MODE2;
 
-    /* Reset mode configuration bits for PA2 and PA3 */
-    GPIOA->MODER &= ~(GPIO_MODER_MODE2 | GPIO_MODER_MODE3);
+    /* Push/Pull mode for PA2 */
+    GPIOA->OTYPER &= ~GPIO_OTYPER_OT_2;
+
+    /* High speed mode for PA2 */
+    GPIOA->OSPEEDR &= ~GPIO_OSPEEDER_OSPEED2;
 
     /* Select alternate function mode for PA2 and PA3 */
-    GPIOA->MODER |= GPIO_MODER_MODE2_1 | GPIO_MODER_MODE3_1;
+    GPIOA->MODER |= GPIO_MODER_MODE2_1;
 
-    /* Select alternate functions 4 of PA2 and PA3 */
-    GPIOA->AFRL &= ~(GPIO_AFRL_AFSEL2_Msk | GPIO_AFRL_AFSEL3_Msk);
-    GPIOA->AFRL |=
-        GPIOA_AFRL_AFSEL2_AF4_USART2_TX |
-        GPIOA_AFRL_AFSEL3_AF4_USART2_RX;
+    /* Select speed for PA2 */
+    GPIOA->OSPEEDR |= GPIO_OSPEEDER_OSPEED2_1;
+
+    /* Alternate function selection for PA2 */
+    GPIOA->AFRL &= ~GPIO_AFRL_AFSEL2_Msk;
+    GPIOA->AFRL |= GPIOA_AFRL_AFSEL2_AF4_USART2_TX;
 
     /* Disable USART2 */
     USART2->CR1 &= ~USART_CR1_UE;
 
-    /* Clear control register values */
-    USART2->CR1 = 0x0U;
-    USART2->CR2 = 0x0U;
-    USART2->CR3 = 0x0U;
-
     /* CR1 configuration */
     /* Word length: 00: 1 Start bit, 8 data bits, n stop bits */
     USART2->CR1 &= ~(USART_CR1_M1 | USART_CR1_M0);
-
-    /* Enable USART2 Transmitter */
-    USART2->CR1 |= USART_CR1_TE;
 
     /* Oversampling
     Select oversampling by 8 (OVER8=1) to achieve higher speed (up to fCK/8).
@@ -90,13 +87,8 @@ usart2_init() {
     receiver to clock deviations. In this case, the maximum speed is limited
     to maximum fCK/16 where fCK is the clock source frequency.
     */
-    USART2->CR1 |= USART_CR1_OVER8;
-
-    /* Clear transfer complete flag */
-    USART2->ICR &= ~USART_ICR_TCCF;
-
-    /* Enable DMA Transmitter */
-    USART2->CR3 |= USART_CR3_DMAT;
+    /* This will cause problem in BAUD rate selection, commented to be dealt later */
+    // USART2->CR1 |= USART_CR1_OVER8;
 
     /* BRR register configuration */
     uint32_t baud_rate = 115200;
@@ -104,8 +96,11 @@ usart2_init() {
     USART2->BRR = (((uartdiv / 16) << USART_BRR_DIV_MANTISSA_Pos) |
             ((uartdiv % 16) << USART_BRR_DIV_FRACTION_Pos));
 
-    /* Enable USART2 */
-    USART2->CR1 |= USART_CR1_UE;
+    /* Enable USART2 Transmitter */
+    USART2->CR1 |= USART_CR1_TE;
+
+    /* Enable USART2 DMA request */
+    USART2->CR3 |= USART_CR3_DMAT;
 }
 
 


### PR DESCRIPTION
Currently PA2 and PA3 are considered to be used as TX and RX pins consecutively, these pins alternative functions can only be used with USART2 and LPUART1 according to stm32l07 datasheet. 

This PR has made some modification to use channel 4 of DMA to transfer data from memory to USART2.